### PR TITLE
feat: add password-based ssh support

### DIFF
--- a/src-tauri/askpass/Cargo.toml
+++ b/src-tauri/askpass/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "askpass"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "askpass"
+path = "src/main.rs"

--- a/src-tauri/askpass/src/main.rs
+++ b/src-tauri/askpass/src/main.rs
@@ -1,0 +1,4 @@
+use std::env;
+fn main() {
+    if let Ok(p) = env::var("APP_SSH_PASS") { print!("{p}"); }
+}

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,12 @@
 fn main() {
-    tauri_build::build()
+    #[cfg(target_os = "macos")]
+    {
+        use std::process::Command;
+        std::fs::create_dir_all("resources").ok();
+        for t in ["aarch64-apple-darwin", "x86_64-apple-darwin"] {
+            Command::new("cargo").args(["build", "--release", "--target", t, "--manifest-path", "askpass/Cargo.toml"]).status().unwrap();
+        }
+        Command::new("lipo").args(["-create", "-output", "resources/askpass", "target/aarch64-apple-darwin/release/askpass", "target/x86_64-apple-darwin/release/askpass"]).status().unwrap();
+    }
+    tauri_build::build();
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,6 +15,18 @@
     "opener:default",
     "log:default",
     "store:default",
-    "core:window:allow-start-dragging"
+    "core:window:allow-start-dragging",
+    "shell:default",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        {
+          "name": "system-ssh",
+          "cmd": "/usr/bin/ssh",
+          "args": true,
+          "sidecar": false
+        }
+      ]
+    }
   ]
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,20 +10,22 @@
     "frontendDist": "../dist"
   },
   "app": {
-      "windows": [
-        {
-          "title": "Codexia - AI Chat Interface",
-          "width": 1200,
-          "height": 800,
-          "minWidth": 800,
-          "minHeight": 600
-        }
-      ],
-      "security": {
-        "csp": null,
-        "capabilities": ["default"]
+    "windows": [
+      {
+        "title": "Codexia - AI Chat Interface",
+        "width": 1200,
+        "height": 800,
+        "minWidth": 800,
+        "minHeight": 600
       }
-    },
+    ],
+    "security": {
+      "csp": null,
+      "capabilities": [
+        "default"
+      ]
+    }
+  },
   "plugins": {
     "store": null,
     "singleInstance": {}
@@ -37,6 +39,9 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "resources": {
+      "resources/askpass": "resources/askpass"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add password field and askpass-based ssh connection
- bundle askpass resource and allow ssh execution

## Testing
- `npm run build`
- `cargo check` *(fails: Permission shell:default not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa89c8fb68832d98df423ca8b732cc