### PR TITLE
build: avoid x86 target requirement for askpass

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -672,6 +672,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-log",
  "tauri-plugin-opener",
+ "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tokio",
@@ -2750,6 +2751,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3845,10 +3856,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+dependencies = [
+ "libc",
+ "sigchld",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sigchld"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -4336,6 +4379,27 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-shell"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b9ffadec5c3523f11e8273465cacb3d86ea7652a28e6e2a2e9b5c182f791d25"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "open",
+ "os_pipe",
+ "regex",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "shared_child",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.14",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,3 +39,4 @@ chrono = { version = "0.4", features = ["serde"] }
 tauri-plugin-log = "2"
 tauri-plugin-store = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-shell = "2"

--- a/src-tauri/askpass/Cargo.toml
+++ b/src-tauri/askpass/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "askpass"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "askpass"
+path = "src/main.rs"

--- a/src-tauri/askpass/src/main.rs
+++ b/src-tauri/askpass/src/main.rs
@@ -1,0 +1,4 @@
+use std::env;
+fn main() {
+    if let Ok(p) = env::var("APP_SSH_PASS") { print!("{p}"); }
+}

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,29 @@
 fn main() {
-    tauri_build::build()
+    #[cfg(not(target_os = "macos"))]
+    {
+        std::fs::create_dir_all("resources").ok();
+        std::fs::write("resources/askpass", []).ok();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        use std::{env, fs, path::Path, process::Command};
+        fs::create_dir_all("resources").ok();
+        let target = env::var("TARGET").unwrap();
+        Command::new("cargo")
+            .args(["build", "--release", "--target", &target, "--manifest-path", "askpass/Cargo.toml"])
+            .status()
+            .unwrap();
+        let arm = Path::new("target/aarch64-apple-darwin/release/askpass");
+        let x86 = Path::new("target/x86_64-apple-darwin/release/askpass");
+        if arm.exists() && x86.exists() {
+            Command::new("lipo")
+                .args(["-create", "-output", "resources/askpass", arm.to_str().unwrap(), x86.to_str().unwrap()])
+                .status()
+                .unwrap();
+        } else {
+            let src = if arm.exists() { arm } else { x86 };
+            fs::copy(src, "resources/askpass").unwrap();
+        }
+    }
+    tauri_build::build();
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,6 +15,17 @@
     "opener:default",
     "log:default",
     "store:default",
-    "core:window:allow-start-dragging"
+    "core:window:allow-start-dragging",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        {
+          "name": "system-ssh",
+          "cmd": "/usr/bin/ssh",
+          "args": true,
+          "sidecar": false
+        }
+      ]
+    }
   ]
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,20 +10,20 @@
     "frontendDist": "../dist"
   },
   "app": {
-      "windows": [
-        {
-          "title": "Codexia - AI Chat Interface",
-          "width": 1200,
-          "height": 800,
-          "minWidth": 800,
-          "minHeight": 600
-        }
-      ],
-      "security": {
-        "csp": null,
-        "capabilities": ["default"]
+    "windows": [
+      {
+        "title": "Codexia - AI Chat Interface",
+        "width": 1200,
+        "height": 800,
+        "minWidth": 800,
+        "minHeight": 600
       }
-    },
+    ],
+    "security": {
+      "csp": null,
+      "capabilities": ["default"]
+    }
+  },
   "plugins": {
     "store": null,
     "singleInstance": {}
@@ -37,6 +37,9 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "resources": {
+      "resources/askpass": "resources/askpass"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add Rust askpass helper
- build askpass for the active macOS target and only lipo when both binaries exist
- bundle askpass and enable system ssh with optional password entry

## Testing
- `npm run build`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68aa89c8fb68832d98df423ca8b732cc